### PR TITLE
[Suggestion] Show the `Required Resistive Heater's Usage` on JEMM page

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mod_description=More Thermal Evaporation Mod adds a More Powerful Thermal Evapor
 mekanism_version=10.4.16.80
 jei_version=15.20.0.105
 # Ver:4.15
-jei_mekanism_multiblocks_version=7176443
+jei_mekanism_multiblocks_version=8714970
 # Ver:1.0.26
 multi_builder_tool_version=8291472
 # Ver:1.2.5

--- a/src/main/java/morethermalevaporation/client/jei/category/MoreEvaporationPlantCategory.java
+++ b/src/main/java/morethermalevaporation/client/jei/category/MoreEvaporationPlantCategory.java
@@ -8,13 +8,18 @@ import giselle.jei_mekanism_multiblocks.client.jei.MultiblockCategory;
 import giselle.jei_mekanism_multiblocks.client.jei.MultiblockWidget;
 import giselle.jei_mekanism_multiblocks.client.jei.ResultWidget;
 import giselle.jei_mekanism_multiblocks.client.jei.category.ICostConsumer;
+import giselle.jei_mekanism_multiblocks.client.jei.category.ResistiveHeaterCategory;
 import giselle.jei_mekanism_multiblocks.common.JEI_MekanismMultiblocks;
 import giselle.jei_mekanism_multiblocks.common.util.VolumeTextHelper;
 import mekanism.api.heat.HeatAPI;
+import mekanism.api.math.FloatingLong;
+import mekanism.common.MekanismLang;
 import mekanism.common.config.MekanismConfig;
+import mekanism.common.content.evaporation.EvaporationMultiblockData;
 import mekanism.common.registries.MekanismBlocks;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.UnitDisplayUtils.TemperatureUnit;
+import mekanism.common.util.text.EnergyDisplay;
 import mekanism.common.util.text.TextUtils;
 import mekanism.generators.common.registries.GeneratorsBlocks;
 import mezz.jei.api.helpers.IGuiHelper;
@@ -279,6 +284,38 @@ public class MoreEvaporationPlantCategory extends MultiblockCategory<MoreEvapora
             consumer.accept(speedWidget);
             consumer.accept(new ResultWidget(Component.translatable("text.jei_mekanism_multiblocks.result.input_tank"), VolumeTextHelper.formatMB(inputCapacity)));
             consumer.accept(new ResultWidget(Component.translatable("text.jei_mekanism_multiblocks.result.output_tank"), VolumeTextHelper.formatMB(outputCapacity)));
+
+            this.createRequiredHeaterEnergyWidget(consumer);
+        }
+
+        private void createRequiredHeaterEnergyWidget(Consumer<AbstractWidget> consumer) {
+            FloatingLong plainRequiredEnergy = this.getRequiredHeaterEnergy(HeatAPI.AMBIENT_TEMP);
+            FloatingLong coldestRequiredEnergy = this.getRequiredHeaterEnergy(HeatAPI.getAmbientTemp(Integer.MIN_VALUE));
+            FloatingLong hotestRequiredEnergy = this.getRequiredHeaterEnergy(HeatAPI.getAmbientTemp(Integer.MAX_VALUE));
+            ResultWidget requiredEnergyWidget = new ResultWidget(Component.translatable("text.jei_mekanism_multiblocks.result.required_heater_usage"), Component.translatable("%s/t", EnergyDisplay.of(plainRequiredEnergy).getTextComponent()));
+            Component heaterName = new ItemStack(MekanismBlocks.RESISTIVE_HEATER).getHoverName();
+            Component valveName = new ItemStack(MekanismBlocks.THERMAL_EVAPORATION_VALVE).getHoverName();
+            requiredEnergyWidget.setTooltip(TooltipHelper.createMessageOnly(//
+                    Component.translatable("text.jei_mekanism_multiblocks.tooltip.required_heater_usage.plain", Component.translatable("%s %s/t", TextUtils.format(plainRequiredEnergy.longValue()), Component.translatable(MekanismLang.ENERGY_JOULES_SHORT.getTranslationKey()))), //
+                    Component.translatable("text.jei_mekanism_multiblocks.tooltip.required_heater_usage.coldest", Component.translatable("%s %s/t", TextUtils.format(coldestRequiredEnergy.longValue()), Component.translatable(MekanismLang.ENERGY_JOULES_SHORT.getTranslationKey()))), //
+                    Component.translatable("text.jei_mekanism_multiblocks.tooltip.required_heater_usage.hottest", Component.translatable("%s %s/t", TextUtils.format(hotestRequiredEnergy.longValue()), Component.translatable(MekanismLang.ENERGY_JOULES_SHORT.getTranslationKey()))), //
+                    Component.translatable("text.jei_mekanism_multiblocks.tooltip.heater_near_and_1_sink_1", heaterName, valveName), //
+                    Component.translatable("text.jei_mekanism_multiblocks.tooltip.heater_near_and_1_sink_2", heaterName, valveName)));
+            consumer.accept(requiredEnergyWidget);
+        }
+
+        public FloatingLong getRequiredHeaterEnergy(double ambientTemp) {
+            double heat = this.getMaxMultiplierHeat(ambientTemp);
+            return ResistiveHeaterCategory.getHeatTransferableEnergy(ambientTemp, heat, HeatAPI.DEFAULT_INVERSE_CONDUCTION).ceil();
+        }
+
+        public double getMaxMultiplierHeat(double ambientTemp) {
+            int activeSolars = this.isUseAdvancedSolarGenerator() ? 4 : 0;
+            double heatCapacity = this.getDimensionHeight() * MekanismConfig.general.evaporationHeatCapacity.get();
+            double maxMultiplierTemp = this.getTier().getMultiplierTemp() * (isUseLargeType() ? MoreThermalEvaporationType.LARGE.getMultiplier() : MoreThermalEvaporationType.NORMAL.getMultiplier());
+            double gain = activeSolars * MekanismConfig.general.evaporationSolarMultiplier.get() * heatCapacity;
+            double loss = MekanismConfig.general.evaporationHeatDissipation.get() * Math.sqrt(Math.abs(maxMultiplierTemp - ambientTemp)) * heatCapacity;
+            return loss - gain;
         }
 
         public long getInputCapacity(MoreThermalEvaporationTier tier, long dimHeight) {

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -83,7 +83,7 @@ side = "BOTH"
 [[dependencies."${mod_id}"]]
 modId = "jei_mekanism_multiblocks"
 mandatory = false
-versionRange = "[4.15,]"
+versionRange = "[4.22,]"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
# 概要

Just Enough Mekanism Multiblocksモードの最新のアップデートから、加温蒸発濃縮プラントのページにプラントが最高速度を維持するために必要とするエネルギーを計算し表示するようになりました。

MoreThermalEvaporationにも適用できると思いましたので、試しにコードを作成してみました。
マージできなくても構いませんので、ご検討をお願いします。

同じ方法で1.21.1バージョンにも適用できます。

# 仕組み

プラントが一定の温度を維持するてことは、入ってくる熱を消滅される熱量が同じてことを意味します。
正確には`MoreThermalEvaporationMultiblockData`の`simulateEnvironment`で加減される熱量と、発熱器がプラントに伝熱する熱量が同じて事になります。

なので`simulateEnvironment`の計算式を逆転すると、プラントが一定の温度を維持するのに必要な熱量が分かります。
その機能は`MoreEvaporationPlantCategory`の`getMaxMultiplierHeat`に具現されています。

そこから得た熱量をJEMMモードにある[`ResistiveHeaterCategory`](https://github.com/gisellevonbingen-Minecraft/JustEnoughMekanismMultiblocks/blob/1.20.1/src/main/java/giselle/jei_mekanism_multiblocks/client/jei/category/ResistiveHeaterCategory.java)の`getHeatTransferableEnergy`メソッドに渡すことで加熱器に入力すべきエネルギー使用量が分かります。

# テストスクショ

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/577f2470-385e-452d-a8e1-b2d75170aeae" />
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/9cff75b6-b0dd-4742-9ffe-74570dfc170d" />
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/f0c0f22a-cade-4fa4-a33d-510fc73a78e8" />
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/6c0a5442-5dc4-4701-a330-b77638c52994" />
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/4cef287c-ce90-4bb3-b4a5-f6f42bcc1bc8" />
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/4f3be47f-eb0a-4e23-bf26-cb5af747a676" />

